### PR TITLE
Remove proprietary cinder volume backup and restore

### DIFF
--- a/cinderclient/client.py
+++ b/cinderclient/client.py
@@ -162,7 +162,6 @@ class SessionClient(adapter.LegacyJsonAdapter):
 
     def request(self, *args, **kwargs):
         kwargs.setdefault('headers', kwargs.get('headers', {}))
-        kwargs['headers']['wrs-header'] = 'true'
         api_versions.update_headers(kwargs["headers"], self.api_version)
         kwargs.setdefault('authenticated', False)
 
@@ -359,7 +358,6 @@ class HTTPClient(object):
         kwargs.setdefault('headers', kwargs.get('headers', {}))
         kwargs['headers']['User-Agent'] = self.USER_AGENT
         kwargs['headers']['Accept'] = 'application/json'
-        kwargs['headers']['wrs-header'] = 'true'
 
         if osprofiler_web:
             kwargs['headers'].update(osprofiler_web.get_trace_id_headers())
@@ -403,7 +401,6 @@ class HTTPClient(object):
             if not self.management_url or not self.auth_token:
                 self.authenticate()
             kwargs.setdefault('headers', {})['X-Auth-Token'] = self.auth_token
-            kwargs['headers']['wrs-header'] = 'true'
             if self.projectid:
                 kwargs['headers']['X-Auth-Project-Id'] = self.projectid
             try:

--- a/cinderclient/tests/unit/test_http.py
+++ b/cinderclient/tests/unit/test_http.py
@@ -105,8 +105,7 @@ class ClientTest(utils.TestCase):
             headers = {"X-Auth-Token": "token",
                        "X-Auth-Project-Id": "project_id",
                        "User-Agent": cl.USER_AGENT,
-                       'Accept': 'application/json',
-                       'wrs-header': 'true', }
+                       'Accept': 'application/json', }
             mock_request.assert_called_with(
                 "GET",
                 "http://example.com/hi",
@@ -129,8 +128,7 @@ class ClientTest(utils.TestCase):
                        "X-Auth-Project-Id": "project_id",
                        "X-OpenStack-Request-ID": global_id,
                        "User-Agent": cl.USER_AGENT,
-                       'Accept': 'application/json',
-                       'wrs-header': 'true', }
+                       'Accept': 'application/json', }
             mock_request.assert_called_with(
                 "GET",
                 "http://example.com/hi",
@@ -300,8 +298,7 @@ class ClientTest(utils.TestCase):
                 "X-Auth-Project-Id": "project_id",
                 "Content-Type": "application/json",
                 'Accept': 'application/json',
-                "User-Agent": cl.USER_AGENT,
-                'wrs-header': 'true',
+                "User-Agent": cl.USER_AGENT
             }
             mock_request.assert_called_with(
                 "POST",
@@ -339,8 +336,7 @@ class ClientTest(utils.TestCase):
             headers = {
                 "Content-Type": "application/json",
                 'Accept': 'application/json',
-                "User-Agent": cl.USER_AGENT,
-                'wrs-header': 'true',
+                "User-Agent": cl.USER_AGENT
             }
             data = {
                 "auth": {

--- a/cinderclient/tests/unit/v1/test_auth.py
+++ b/cinderclient/tests/unit/v1/test_auth.py
@@ -60,7 +60,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -134,7 +133,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -237,7 +235,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -289,8 +286,7 @@ class AuthenticationTests(utils.TestCase):
                 'X-Auth-User': 'username',
                 'X-Auth-Key': 'password',
                 'X-Auth-Project-Id': 'project_id',
-                'User-Agent': cs.client.USER_AGENT,
-                'wrs-header': 'true',
+                'User-Agent': cs.client.USER_AGENT
             }
             mock_request.assert_called_with(
                 "GET",

--- a/cinderclient/tests/unit/v2/test_auth.py
+++ b/cinderclient/tests/unit/v2/test_auth.py
@@ -63,7 +63,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -137,7 +136,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -240,7 +238,6 @@ class AuthenticateAgainstKeystoneTests(utils.TestCase):
                 'User-Agent': cs.client.USER_AGENT,
                 'Content-Type': 'application/json',
                 'Accept': 'application/json',
-                'wrs-header': 'true',
             }
             body = {
                 'auth': {
@@ -292,8 +289,7 @@ class AuthenticationTests(utils.TestCase):
                 'X-Auth-User': 'username',
                 'X-Auth-Key': 'password',
                 'X-Auth-Project-Id': 'project_id',
-                'User-Agent': cs.client.USER_AGENT,
-                'wrs-header': 'true',
+                'User-Agent': cs.client.USER_AGENT
             }
             mock_request.assert_called_with(
                 "GET",

--- a/cinderclient/v1/shell.py
+++ b/cinderclient/v1/shell.py
@@ -15,9 +15,6 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 
 from __future__ import print_function
@@ -1455,46 +1452,3 @@ def do_set_bootable(cs, args):
     cs.volumes.set_bootable(volume,
                             strutils.bool_from_string(args.bootable,
                                                       strict=True))
-
-
-@utils.arg('volume',
-           metavar='<volume>',
-           help='Name or ID of the volume to export')
-def do_export(cs, args):
-    """Export volume to a file."""
-    volume = utils.find_volume(cs, args.volume)
-    updated_volume = volume.export()
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_export'])
-
-
-@utils.arg('file_name',
-           metavar='<file-name>',
-           help='Name of the file to import')
-def do_import(cs, args):
-    """Import a volume from a file."""
-
-    # Parse the volume ID from the filename which is in this format:
-    #   volume-<id>-<timestamp>.tgz
-    # For example:
-    #   volume-3a2cae29-850d-4445-b9ae-03865080b915-20140821-162819.tgz
-    if (args.file_name.find("volume-") != 0 or
-        args.file_name.rfind(".tgz") == -1 or
-            len(args.file_name) < 28):
-        raise exceptions.CommandError(
-            "Invalid filename - volume files must have the following format: "
-            "volume-<id>-<timestamp>.tgz")
-
-    volume_id = args.file_name[7:-20]
-    volume = utils.find_volume(cs, volume_id)
-    updated_volume = volume.import_volume(args.file_name)
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_import'])
-
-
-@utils.arg('snapshot',
-           metavar='<snapshot>',
-           help='Name or ID of the snapshot to export')
-def do_snapshot_export(cs, args):
-    """Export a snapshot to a file."""
-    snapshot = _find_volume_snapshot(cs, args.snapshot)
-    updated_snapshot = snapshot.export()
-    utils.print_dict(updated_snapshot[1]['wrs-snapshot:os-export_snapshot'])

--- a/cinderclient/v1/volume_snapshots.py
+++ b/cinderclient/v1/volume_snapshots.py
@@ -12,9 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 
 """
@@ -75,10 +72,6 @@ class Snapshot(base.Resource):
     def update_all_metadata(self, metadata):
         """Update_all metadata of this snapshot."""
         return self.manager.update_all_metadata(self, metadata)
-
-    def export(self):
-        """Export this snapshot."""
-        return self.manager.export(self)
 
 
 class SnapshotManager(base.ManagerWithFind):
@@ -203,11 +196,3 @@ class SnapshotManager(base.ManagerWithFind):
         body = {'metadata': metadata}
         return self._update("/snapshots/%s/metadata" % base.getid(snapshot),
                             body)
-
-    def export(self, snapshot):
-        """Export the snapshot to a file.
-
-        :param snapshot: The :class:`Snapshot`.
-        """
-        return self._action('wrs-snapshot:os-export_snapshot',
-                            snapshot)

--- a/cinderclient/v1/volumes.py
+++ b/cinderclient/v1/volumes.py
@@ -12,9 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 
 """
@@ -135,14 +132,6 @@ class Volume(base.Resource):
             read-only access mode.
         """
         self.manager.update_readonly_flag(self, read_only)
-
-    def export(self):
-        """Export a volume to a file."""
-        return self.manager.export(self)
-
-    def import_volume(self, file_name):
-        """Import a volume from a file."""
-        return self.manager.import_volume(self, file_name)
 
 
 class VolumeManager(base.ManagerWithFind):
@@ -438,23 +427,3 @@ class VolumeManager(base.ManagerWithFind):
         return self._action('os-set_bootable',
                             base.getid(volume),
                             {'bootable': flag})
-
-    def export(self, volume):
-        """
-        Export volume to a file.
-
-        :param volume: The :class:`Volume` to export.
-        """
-        return self._action('wrs-volume:os-volume_export',
-                            volume)
-
-    def import_volume(self, volume, file_name):
-        """
-        Import volume from a file.
-
-        :param volume: The :class:`Volume` to import.
-        :param file_name: The file to import.
-        """
-        return self._action('wrs-volume:os-volume_import',
-                            volume,
-                            {'file_name': file_name})

--- a/cinderclient/v2/shell.py
+++ b/cinderclient/v2/shell.py
@@ -13,9 +13,6 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-#  Copyright (c) 2013-2018 Wind River Systems, Inc.
-#
 
 from __future__ import print_function
 
@@ -2541,40 +2538,3 @@ def do_snapshot_manageable_list(cs, args):
     if detailed:
         columns.extend(['reason_not_safe', 'cinder_id', 'extra_info'])
     utils.print_list(snapshots, columns, sortby_index=None)
-
-
-# WRS extensiion
-@utils.arg('volume',
-           metavar='<volume>',
-           help='Name or ID of the volume to export')
-def do_export(cs, args):
-    """Export volume to a file."""
-    volume = utils.find_volume(cs, args.volume)
-    updated_volume = volume.export()
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_export'])
-
-
-# WRS extension
-@utils.arg('file_name',
-           metavar='<file-name>',
-           help='Name of the file to import')
-@utils.arg('--file_name',
-           help=argparse.SUPPRESS)
-def do_import(cs, args):
-    """Import a volume from a file."""
-
-    # Parse the volume ID from the filename which is in this format:
-    #   volume-<id>-<timestamp>.tgz
-    # For example:
-    #   volume-3a2cae29-850d-4445-b9ae-03865080b915-20140821-162819.tgz
-    if (args.file_name.find("volume-") != 0 or
-        args.file_name.rfind(".tgz") == -1 or
-            len(args.file_name) < 28):
-        raise exceptions.CommandError(
-            "Invalid filename - volume files must have the following format: "
-            "volume-<id>-<timestamp>.tgz")
-
-    volume_id = args.file_name[7:-20]
-    volume = utils.find_volume(cs, volume_id)
-    updated_volume = volume.import_volume(args.file_name)
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_import'])

--- a/cinderclient/v2/volumes.py
+++ b/cinderclient/v2/volumes.py
@@ -12,9 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-#
-#  Copyright (c) 2013-2018 Wind River Systems, Inc.
-#
 
 """Volume interface (v2 extension)."""
 
@@ -651,25 +648,3 @@ class VolumeManager(base.ManagerWithFind):
             query_string = "?detail=True"
 
         return self._get('/scheduler-stats/get_pools%s' % query_string, None)
-
-    # WRS extension
-    def export(self, volume):
-        """
-        Export volume to a file.
-
-        :param volume: The :class:`Volume` to export.
-        """
-        return self._action('wrs-volume:os-volume_export',
-                            volume)
-
-    # WRS extension
-    def import_volume(self, volume, file_name):
-        """
-        Import volume from a file.
-
-        :param volume: The :class:`Volume` to import.
-        :param file_name: The file to import.
-        """
-        return self._action('wrs-volume:os-volume_import',
-                            volume,
-                            {'file_name': file_name})

--- a/cinderclient/v3/shell.py
+++ b/cinderclient/v3/shell.py
@@ -13,9 +13,6 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 
 from __future__ import print_function
@@ -2017,48 +2014,3 @@ def do_service_get_log(cs, args):
                                             args.prefix)
     columns = ('Binary', 'Host', 'Prefix', 'Level')
     utils.print_list(log_levels, columns)
-
-
-@utils.arg('volume',
-           metavar='<volume>',
-           help='Name or ID of the volume to export')
-def do_export(cs, args):
-    """Export volume to a file."""
-    volume = utils.find_volume(cs, args.volume)
-    updated_volume = volume.export()
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_export'])
-
-
-@utils.arg('file_name',
-           metavar='<file-name>',
-           help='Name of the file to import')
-@utils.arg('--file_name',
-           help=argparse.SUPPRESS)
-def do_import(cs, args):
-    """Import a volume from a file."""
-
-    # Parse the volume ID from the filename which is in this format:
-    #   volume-<id>-<timestamp>.tgz
-    # For example:
-    #   volume-3a2cae29-850d-4445-b9ae-03865080b915-20140821-162819.tgz
-    if (args.file_name.find("volume-") != 0 or
-        args.file_name.rfind(".tgz") == -1 or
-            len(args.file_name) < 28):
-        raise exceptions.CommandError(
-            "Invalid filename - volume files must have the following format: "
-            "volume-<id>-<timestamp>.tgz")
-
-    volume_id = args.file_name[7:-20]
-    volume = utils.find_volume(cs, volume_id)
-    updated_volume = volume.import_volume(args.file_name)
-    utils.print_dict(updated_volume[1]['wrs-volume:os-volume_import'])
-
-
-@utils.arg('snapshot',
-           metavar='<snapshot>',
-           help='Name or ID of the snapshot to export')
-def do_snapshot_export(cs, args):
-    """Export a snapshot to a file."""
-    snapshot = _find_volume_snapshot(cs, args.snapshot)
-    updated_snapshot = snapshot.export()
-    utils.print_dict(updated_snapshot[1]['wrs-snapshot:os-export_snapshot'])

--- a/cinderclient/v3/volume_snapshots.py
+++ b/cinderclient/v3/volume_snapshots.py
@@ -12,9 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 """Volume snapshot interface (v3 extension)."""
 
@@ -80,10 +77,6 @@ class Snapshot(base.Resource):
     def unmanage(self, snapshot):
         """Unmanage a snapshot."""
         self.manager.unmanage(snapshot)
-
-    def export(self):
-        """Export this snapshot."""
-        return self.manager.export(self)
 
 
 class SnapshotManager(base.ManagerWithFind):
@@ -241,11 +234,3 @@ class SnapshotManager(base.ManagerWithFind):
     def unmanage(self, snapshot):
         """Unmanage a snapshot."""
         return self._action('os-unmanage', snapshot, None)
-
-    def export(self, snapshot):
-        """Export the snapshot to a file.
-
-        :param snapshot: The :class:`Snapshot`.
-        """
-        return self._action('wrs-snapshot:os-export_snapshot',
-                            snapshot)

--- a/cinderclient/v3/volumes.py
+++ b/cinderclient/v3/volumes.py
@@ -12,9 +12,6 @@
 #    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 #    License for the specific language governing permissions and limitations
 #    under the License.
-#
-# Copyright (c) 2014 Wind River Systems, Inc.
-#
 
 """Volume interface (v3 extension)."""
 from cinderclient.apiclient import base as common_base
@@ -51,14 +48,6 @@ class Volume(volumes.Volume):
     def revert_to_snapshot(self, snapshot):
         """Revert a volume to a snapshot."""
         self.manager.revert_to_snapshot(self, snapshot)
-
-    def export(self):
-        """Export a volume to a file."""
-        return self.manager.export(self)
-
-    def import_volume(self, file_name):
-        """Import a volume from a file."""
-        return self.manager.import_volume(self, file_name)
 
 
 class VolumeManager(volumes.VolumeManager):
@@ -232,23 +221,3 @@ class VolumeManager(volumes.VolumeManager):
                                    search_opts=options)
 
         return self._get(url, None)
-
-    def export(self, volume):
-        """
-        Export volume to a file.
-
-        :param volume: The :class:`Volume` to export.
-        """
-        return self._action('wrs-volume:os-volume_export',
-                            volume)
-
-    def import_volume(self, volume, file_name):
-        """
-        Import volume from a file.
-
-        :param volume: The :class:`Volume` to import.
-        :param file_name: The file to import.
-        """
-        return self._action('wrs-volume:os-volume_import',
-                            volume,
-                            {'file_name': file_name})


### PR DESCRIPTION
With the removal of proprietary cinder volume backup and restore,
the B&R procedure is altered to only support B&R on systems with
no LVM or internal ceph backed cinder volumes. A future activity
will update the B&R procedure to support cinder volumes handling.

Story: 2003115
Task: 23234